### PR TITLE
Bugfix: SeekMiner.cpp param ordering when calling seekcentral.cpp:Initialize()

### DIFF
--- a/tools/SeekMiner/SeekMiner.cpp
+++ b/tools/SeekMiner/SeekMiner.cpp
@@ -397,11 +397,11 @@ int main(int iArgs, char **aszArgs) {
                              eDistMeasure, bVariance,
                              !!sArgs.norm_subavg_flag, !!sArgs.norm_subavg_plat_flag,
                              false,
-                             !!sArgs.check_dset_size_flag,
                              sArgs.score_cutoff_arg,
                              sArgs.per_q_required_arg, sArgs.per_g_required_arg,
                              !!sArgs.square_z_flag,
                              !!sArgs.random_flag, sArgs.num_random_arg, !!sArgs.neg_cor_flag,
+                             !!sArgs.check_dset_size_flag,
                              random_ranking_rnd, useNibble,
                              sArgs.num_threads_arg))
         return -1;


### PR DESCRIPTION
Bugfix: SeekMiner.cpp when calling seekcentral.cpp:Initialize() passes the checkDatasetFlag parameter in wrong parameter position. This bug was introduced when the checkDatasetSize addition was made in bitbucket change f8fc60d 02/20/2015.