### PR TITLE
SeekCentral keep query scores (don't set to NA)

### DIFF
--- a/src/seekcentral.cpp
+++ b/src/seekcentral.cpp
@@ -1355,7 +1355,7 @@ namespace Sleipnir {
 
             //Display(query, final);
             //fprintf(stderr, "4 %lu\n", CMeta::GetMemoryUsage());
-            SetQueryScoreNull(query);
+            // SetQueryScoreNull(query);  // commented out 6/2016 by qzhu
             Sort(final);
             int ret; //for system calls
 

--- a/tools/SeekServer/SeekServer.cpp
+++ b/tools/SeekServer/SeekServer.cpp
@@ -449,7 +449,7 @@ int main(int iArgs, char **aszArgs) {
         string strSearchDataset;
         string strQuery;
         string strOutputDir;
-        string strGuideGeneSet;
+        string strGuideGeneSet = "null";
 
         //search parameters
         string strSearchParameter;


### PR DESCRIPTION
SeekCentral keep query scores. SeekServer guideGenes must be set to "null" by default